### PR TITLE
add-incremental-search-function

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -4,8 +4,6 @@ $(function() {
     $('.messages__message').animate({
       scrollTop:$('.last_message').offset().top});  
   }
-  scrollLast();
-
   function buildHTML(message){
     if (message.image.url == null) {
       var image_html = ``

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,0 +1,45 @@
+$(function() {
+
+  var search_result = $("#user-search-result");
+
+  function appendUser(user) {
+    var html = `<div class="chat-group-user clearfix">
+                  <p class="chat-group-user__name">${user.name}</p>
+                  <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加</div>
+                </div>`
+    search_result.append(html)
+  }
+
+  function appendErrMsgToHTML() {
+    var html = `<div class="chat-group-user clearfix">
+                <p class="chat-group-user__name">ユーザーが見つかりません</p>
+                </div>`
+    search_result.append(html);
+  }
+
+
+  $("#user-search-field").on("keyup", function() {
+    var input = $("#user-search-field").val();
+
+    $.ajax({
+      type: 'GET',
+      url: '/users',
+      data: { keyword: input },
+      dataType: 'json'
+    })
+    .done(function(users){
+      search_result.empty();
+      if (users.length !==0) {
+        users.forEach(function(user){
+          appendUser(user);
+        })
+      }
+      else {
+        appendErrMsgToHTML();
+      }
+    })
+    .fail(function(){
+      alert('ユーザー検索に失敗しました');
+    })
+  })
+})

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -17,6 +17,17 @@ $(function() {
     search_result.append(html);
   }
 
+  function addUser(user_name, user_id) {
+    var html = `
+                <div class='chat-group-user'>
+                  <input name='group[user_ids][]' type='hidden' value='${user_id}'>
+                  <p class='chat-group-user__name'>${user_name}</p>
+                  <div class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</div>
+                </div>
+                `
+    $('#chat-group-users').append(html);
+  }
+
 
   $("#user-search-field").on("keyup", function() {
     var input = $("#user-search-field").val();
@@ -41,5 +52,16 @@ $(function() {
     .fail(function(){
       alert('ユーザー検索に失敗しました');
     })
+  });
+
+  $(document).on('click', ".chat-group-user__btn--add", function(){
+    var user_id = $(this).data('user-id');
+    var user_name = $(this).data('user-name');
+    $(this).parent().remove();
+    addUser(user_name, user_id)
+  });
+
+  $(document).on('click', ".chat-group-user__btn--remove", function(){
+    $(this).parent().remove();
   })
 })

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -23,7 +23,6 @@ class GroupsController < ApplicationController
   end
 
   def update
-    binding.pry
     if @group.update(group_params)
       redirect_to group_messages_path(@group), notice: 'グループを編集しました'
     else

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -23,6 +23,7 @@ class GroupsController < ApplicationController
   end
 
   def update
+    binding.pry
     if @group.update(group_params)
       redirect_to group_messages_path(@group), notice: 'グループを編集しました'
     else
@@ -33,7 +34,7 @@ class GroupsController < ApplicationController
   private
 
   def group_params
-    params.require(:group).permit(:name, { :user_ids => [] })
+    params.require(:group).permit(:name, { user_ids: [] })
   end
 
   def set_group

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,13 @@
 class UsersController < ApplicationController
 
+  def index
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%")
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
   def edit
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
 
   def index
-    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%")
+    @users = User.where('id != ?',current_user.id ).where('name LIKE(?)', "%#{params[:keyword]}%")
     respond_to do |format|
       format.html
       format.json

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -24,12 +24,12 @@
     .chat-group-form__field--right
       #chat-group-users.js-add-user
         .chat-group-user.clearfix.js-chat-member#chat-group-user-8
-          = f.hidden_field "[user_ids][]", value: current_user.id, name: "[user_ids][]"
+          = f.hidden_field "group[user_ids][]", value: current_user.id, name: "group[user_ids][]"
           %p.chat-group-user__name= current_user.name
         - group.users.each do |user|
           - unless user == current_user
             .chat-group-user.clearfix.js-chat-member
-              = f.hidden_field "[user_ids][]", value: user.id, name: "[user_ids][]"
+              = f.hidden_field "group[user_ids][]", value: user.id, name: "group[user_ids][]"
               %p.chat-group-user__name= user.name
               .user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn
                 削除

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -24,12 +24,12 @@
     .chat-group-form__field--right
       #chat-group-users.js-add-user
         .chat-group-user.clearfix.js-chat-member#chat-group-user-8
-          %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
+          = f.hidden_field 'user_ids][', value: current_user.id
           %p.chat-group-user__name= current_user.name
         - group.users.each do |user|
           - unless user == current_user
             .chat-group-user.clearfix.js-chat-member
-              %input{name: "group[user_ids][]", type: "hidden", value: user.id}
+              = f.hidden_field "user_ids][", value: user.id
               %p.chat-group-user__name= user.name
               .user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn
                 削除

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -24,12 +24,12 @@
     .chat-group-form__field--right
       #chat-group-users.js-add-user
         .chat-group-user.clearfix.js-chat-member#chat-group-user-8
-          = f.hidden_field 'user_ids][', value: current_user.id
+          = f.hidden_field "[user_ids][]", value: current_user.id, name: "[user_ids][]"
           %p.chat-group-user__name= current_user.name
         - group.users.each do |user|
           - unless user == current_user
             .chat-group-user.clearfix.js-chat-member
-              = f.hidden_field "user_ids][", value: user.id
+              = f.hidden_field "[user_ids][]", value: user.id, name: "[user_ids][]"
               %p.chat-group-user__name= user.name
               .user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn
                 削除

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -12,15 +12,15 @@
       = f.text_field :name, placeholder: 'グループ名を入力してください', class: "chat-group-form__input", id: "chat_group_name"
   .chat-group-form__field
     .chat-group-form__field--left
-      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+      = f.label :チャットメンバーを追加, class: "chat-group-form__label"
     .chat-group-form__field--right
       .chat-group-form__search.clearfix
-        %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+        %input#user-search-field.chat-group-form__input{placeholder: "追加したいユーザー名を入力してください", type: "text"}/
       #user-search-result
       
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
-      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+      = f.label :チャットメンバー, class: "chat-group-form__label"
     .chat-group-form__field--right
       #chat-group-users.js-add-user
         .chat-group-user.clearfix.js-chat-member#chat-group-user-8

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -23,6 +23,16 @@
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
       #chat-group-users.js-add-user
+        .chat-group-user.clearfix.js-chat-member#chat-group-user-8
+          %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
+          %p.chat-group-user__name= current_user.name
+        - group.users.each do |user|
+          - unless user == current_user
+            .chat-group-user.clearfix.js-chat-member
+              %input{name: "group[user_ids][]", type: "hidden", value: user.id}
+              %p.chat-group-user__name= user.name
+              .user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn
+                削除
 
   .chat-group-form__field.clearfix
     .chat-group-form__field--left

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -11,14 +11,20 @@
     .chat-group-form__field--right
       = f.text_field :name, placeholder: 'グループ名を入力してください', class: "chat-group-form__input", id: "chat_group_name"
   .chat-group-form__field
-    / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
-  .chat-group-form__field
     .chat-group-form__field--left
-      = f.label :チャットメンバー, class: "chat-group-form__label"
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
     .chat-group-form__field--right
-      = f.collection_check_boxes(:user_ids, User.all, :id, :name)
-      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
-  .chat-group-form__field
+      .chat-group-form__search.clearfix
+        %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+      #user-search-result
+      
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+    .chat-group-form__field--right
+      #chat-group-users.js-add-user
+
+  .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right
       = f.submit "登録する", class: "chat-group-form__action-btn", name: "commit", type: "submit"

--- a/app/views/groups/_group.html.haml
+++ b/app/views/groups/_group.html.haml
@@ -1,5 +1,5 @@
 .menu__group
-  =link_to group_messages_path(group), data: {"turbolinks" => false} do
+  =link_to group_messages_path(group), data: {turbolinks: false} do
     .menu__group--name
       = group.name
     .menu__group--message

--- a/app/views/layouts/_groups.html.haml
+++ b/app/views/layouts/_groups.html.haml
@@ -3,7 +3,7 @@
     .menu__user--name 
       = current_user.name
     .menu__user--edit
-      =link_to new_group_path do
+      =link_to new_group_path, data: {turbolinks: false} do
         =fa_icon 'edit'
       =link_to edit_user_path(current_user) do
         =fa_icon 'gear'

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -6,9 +6,9 @@
         = @group.name
       .messages__group--members
         Members: 
-        - @group.users.each do |user|
+        - @group.users.order(name: "ASC").each do |user|
           = user.name
-    =link_to edit_group_path(@group) do
+    =link_to edit_group_path(@group), data: {turbolinks: false} do
       .messages__group--edit
         Edit
   .messages__message

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'groups#index'
-  resources :users, only: [:edit, :update]
+  resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :show, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end


### PR DESCRIPTION
## what
chat-spaceのグループ作成・編集画面にて、ユーザーを追加する際にインクリメンタルサーチでユーザーを検索できる機能を追加する。
検索したユーザーを追加したり、追加しているメンバーを削除する機能を合わせて実装する。
その際、ログイン中のメンバーは常に参加するようにし、ログイン中メンバーに対しての削除ボタンを表示させないようにする。

## why
登録ユーザー数が多くなった場合に、全てのユーザー名を画面に表示させると煩雑になってしまうため、検索されたユーザーのみを表示させるようにして希望のユーザーを探しやすくするため。
ログイン中のユーザーを削除できなくするのは、削除した後では今まで参加していたグループへの再参加が自力ではできなくなるため。ユーザー不在のグループができることを防ぐ狙いもある。

#### 補足
現状ではすでに追加しているメンバーも検索結果に表示されてしまう。
これはカリキュラムを進め、余裕ができた時に修正を検討する。